### PR TITLE
feat(pctx-py): replace deprecated api_key with arbitrary headers

### DIFF
--- a/pctx-py/CHANGELOG.md
+++ b/pctx-py/CHANGELOG.md
@@ -11,7 +11,21 @@ For changes to the underlying Rust crates and CLI, see the
 
 ## [UNRELEASED] - YYYY-MM-DD
 
-## [v0.4.0] - 2026-06-08
+### Added
+
+- `Pctx(headers=...)`: an arbitrary `dict[str, str]` of headers applied to every
+  HTTP request and the WebSocket connection request. Use this to authenticate
+  against deployments that expect custom headers (e.g. a
+  `{"authorization": "Bearer <token>"}` for GCP IAM-protected services).
+
+### Removed
+
+- **Breaking**: the deprecated `Pctx(api_key=...)` parameter and the
+  `x-pctx-api-key` header it set. The system that validated this key is no
+  longer maintained. Pass credentials via `headers=` instead — e.g.
+  `Pctx(api_key="k")` → `Pctx(headers={"x-pctx-api-key": "k"})`.
+
+## [v0.4.1] - 2026-06-08
 
 ### Added
 - `py.typed` for mypy

--- a/pctx-py/src/pctx_client/_client.py
+++ b/pctx-py/src/pctx_client/_client.py
@@ -65,7 +65,7 @@ class Pctx:
         tools: list[Tool | AsyncTool] | None = None,
         servers: list[ServerConfig] | None = None,
         url: str = "http://localhost:8080",
-        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
         execute_timeout: float = 30.0,
     ):
         """
@@ -77,6 +77,8 @@ class Pctx:
                 - HTTP server: {"name": "...", "url": "...", "auth": {...}}
                 - stdio server: {"name": "...", "command": "...", "args": [...], "env": {...}}
             url: PCTX server URL (default: http://localhost:8080)
+            headers: Additional headers applied to every request and the
+                WebSocket connection request
             execute_timeout: Timeout for code execution in seconds (default: 30.0)
         """
 
@@ -100,14 +102,14 @@ class Pctx:
         ws_scheme = "wss" if http_scheme == "https" else "ws"
 
         self._ws_client = WebSocketClient(
-            url=f"{ws_scheme}://{host}{parsed.path}/ws", api_key=api_key, tools=tools
+            url=f"{ws_scheme}://{host}{parsed.path}/ws", headers=headers, tools=tools
         )
         self._client = AsyncClient(
             base_url=f"{http_scheme}://{host}{parsed.path}",
-            headers={"x-pctx-api-key": api_key or ""},
+            headers=headers or {},
         )
         self._session_id: str | None = None
-        self._api_key = api_key
+        self._headers = headers or {}
 
         self._tools = tools or []
         self._servers = servers or []

--- a/pctx-py/src/pctx_client/_websocket_client.py
+++ b/pctx-py/src/pctx_client/_websocket_client.py
@@ -52,7 +52,7 @@ class WebSocketClient:
     def __init__(
         self,
         url: str,
-        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
         tools: list[Tool | AsyncTool] | None = None,
     ):
         """
@@ -60,11 +60,12 @@ class WebSocketClient:
 
         Args:
             url: WebSocket server URL (e.g., "ws://localhost:8080/ws")
+            headers: Additional headers to send with the connection request
         """
         self.url = url
         self.ws: ClientConnection | None = None
         self.tools = tools or []
-        self._api_key = api_key
+        self._headers = headers or {}
         self._pending_executions: dict[str | int, asyncio.Future] = {}
         self._request_counter = 0
 
@@ -77,8 +78,8 @@ class WebSocketClient:
         """
         try:
             headers = {
+                **self._headers,
                 "x-code-mode-session": code_mode_session,
-                "x-pctx-api-key": self._api_key or "",
             }
             self.ws = await websockets.connect(self.url, additional_headers=headers)
         except Exception as e:

--- a/pctx-py/tests/scripts/manual_code_mode.py
+++ b/pctx-py/tests/scripts/manual_code_mode.py
@@ -48,7 +48,7 @@ def multiply(a: float, b: float) -> MultiplyOutput:
 async def main():
     async with Pctx(
         # url="https://....",
-        # api_key="pctx_xxxx",
+        # headers={"authorization": "Bearer xxxx"},
         tools=[add, subtract, multiply, now_timestamp, search_logs],
         servers=[
             {


### PR DESCRIPTION
## Summary

The `api_key` parameter on the `Pctx` client is deprecated — the system that validated the key is no longer maintained. This replaces it with a `headers: dict[str, str] | None` parameter: an arbitrary set of headers applied to **every HTTP request** and the **WebSocket connection request**.

No backwards-compatible shim is retained; `api_key` and the `x-pctx-api-key` header are removed entirely.

## Changes

- **`_client.py`** — `Pctx.__init__` now takes `headers` instead of `api_key`; spreads them into the `httpx.AsyncClient` and forwards them to the `WebSocketClient`.
- **`_websocket_client.py`** — `WebSocketClient` takes `headers` and merges them into the connect request. The reserved `x-code-mode-session` header is applied *after* caller headers so it can't be clobbered.
- **`manual_code_mode.py`** — updated the commented example to `headers={"authorization": "Bearer xxxx"}`.

Remaining `api_key` references in the repo (README, crewai/langchain scripts) are OpenRouter LLM keys and are unrelated.

## Type choice

`dict[str, str] | None` — covers every practical "arbitrary headers" use. It cannot express duplicate header keys, but clients essentially never need repeated header names; the type can be widened later without a breaking change.

## Verification

`make lint` and `make typecheck` pass. Client imports and instantiates with `headers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)