### PR TITLE
Bound large execute_code responses to the WebSocket frame limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bound `execute_code` responses under the 16 MiB WebSocket frame limit: oversized responses (usually from a bloated trace, occasionally from a huge return value or stdout) previously exceeded the frame limit and silently failed to reach the client. The response is now shrunk before sending — dropping the trace first, then replacing the return value with a truncation marker if still too large.
+
 ## [v0.7.1] - 2026-03-27
 
 ### Added

--- a/crates/pctx_session_server/src/websocket/handler.rs
+++ b/crates/pctx_session_server/src/websocket/handler.rs
@@ -33,6 +33,7 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::AppState;
+use crate::websocket::truncate::bound_response_size;
 
 /// Handle WebSocket upgrade
 pub async fn ws_handler<B: PctxSessionBackend>(
@@ -291,7 +292,9 @@ async fn handle_execute_code_request<B: PctxSessionBackend>(
         .await;
 
         let (msg, execution_res) = match output {
-            Ok(Ok(exec_output)) => {
+            Ok(Ok(mut exec_output)) => {
+                // Keep the response within the WebSocket frame limit before sending.
+                bound_response_size(&mut exec_output);
                 if let Err(e) = state
                     .backend
                     .set_pool(code_mode_session_id, exec_output.registry.pool())

--- a/crates/pctx_session_server/src/websocket/mod.rs
+++ b/crates/pctx_session_server/src/websocket/mod.rs
@@ -1,3 +1,4 @@
 mod handler;
+mod truncate;
 
 pub use handler::*;

--- a/crates/pctx_session_server/src/websocket/truncate.rs
+++ b/crates/pctx_session_server/src/websocket/truncate.rs
@@ -1,0 +1,49 @@
+//! Bounds `execute_code` responses to fit the WebSocket frame limit.
+//! Temporary solution until long term solution is implemented, see plans/large-execution-payloads.md
+
+use pctx_code_mode::model::{ExecuteTypescriptOutput, ExecutionTrace};
+use serde_json::json;
+use tracing::warn;
+
+/// Response-size ceiling. tungstenite's default `max_frame_size` is 16 MiB and
+/// is enforced by the receiver (the client), which can't advertise its cap to
+/// us — so we stay under the default with a margin.
+pub(super) const MAX_RESPONSE_BYTES: usize = 15 * 1024 * 1024;
+
+/// Serialized wire size of an execution output.
+fn serialized_len(output: &ExecuteTypescriptOutput) -> usize {
+    serde_json::to_vec(output).map_or(0, |v| v.len())
+}
+
+/// Shrink an oversized response to fit [`MAX_RESPONSE_BYTES`]: first drop the
+/// trace, then, if still too large, replace the return value with a marker and
+/// note on stderr why it's gone so the calling agent can see it.
+pub(super) fn bound_response_size(output: &mut ExecuteTypescriptOutput) {
+    if serialized_len(output) <= MAX_RESPONSE_BYTES {
+        return;
+    }
+
+    // The trace clones every tool output, so it's usually the culprit.
+    let before = serialized_len(output);
+    output.trace = ExecutionTrace::default();
+    warn!("execute_code response {before} bytes over {MAX_RESPONSE_BYTES}; dropped trace");
+
+    if serialized_len(output) <= MAX_RESPONSE_BYTES {
+        return;
+    }
+
+    // The return value / stdout are themselves too large.
+    let oversized = serialized_len(output);
+    let notice = format!(
+        "[truncated: output was {oversized} bytes, over the {MAX_RESPONSE_BYTES}-byte transport limit; return value not delivered]"
+    );
+    warn!("{notice}");
+    output.output = Some(json!({ "__truncated__": true, "reason": notice.clone() }));
+    output.stdout = String::new();
+    if output.stderr.is_empty() {
+        output.stderr = notice;
+    } else {
+        output.stderr.push('\n');
+        output.stderr.push_str(&notice);
+    }
+}

--- a/crates/pctx_session_server/tests/executions.rs
+++ b/crates/pctx_session_server/tests/executions.rs
@@ -430,6 +430,47 @@ async fn test_exec_large_trace_still_sends() {
     assert_eq!(response["result"]["output"], json!(expected_sum));
 }
 
+/// A script that returns a value larger than the frame limit. Dropping the trace
+/// isn't enough here, so the return value itself is truncated to a marker and an
+/// explanatory notice is surfaced on stderr — but the response still sends.
+#[tokio::test]
+#[serial]
+async fn test_exec_large_output_truncates_and_sends() {
+    let (session_id, server, _) = create_test_server_with_session().await;
+
+    let mut ws = connect_websocket(&server, session_id)
+        .await
+        .into_websocket()
+        .await;
+
+    // Return a ~20 MiB string directly, over the 15 MiB response limit.
+    let code = r#"async function run() { return "A".repeat(20 * 1024 * 1024); }"#;
+
+    ws.send_json(&json!({
+        "jsonrpc": "2.0",
+        "id": "test-large-output",
+        "method": "execute_code",
+        "params": { "code": code, "disclosure": "sidecar" }
+    }))
+    .await;
+
+    // The response must still send despite the oversized return value.
+    let response: serde_json::Value = ws.receive_json().await;
+    let result = &response["result"];
+
+    assert_eq!(result["success"], json!(true));
+    // Output replaced with the truncation marker.
+    assert_eq!(result["output"]["__truncated__"], json!(true));
+    // The agent is told why via stderr.
+    assert!(
+        result["stderr"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("truncated"),
+        "stderr should carry the truncation notice: {result:?}"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn test_exec_type_error_with_rich_diagnostics() {

--- a/crates/pctx_session_server/tests/executions.rs
+++ b/crates/pctx_session_server/tests/executions.rs
@@ -345,6 +345,91 @@ async fn test_exec_callbacks(#[case] code: &str, #[case] disclosure: &str) {
     );
 }
 
+/// A tool returning a large `{ val, text }` is called `N_CALLS` times, but the script only returns
+/// the sum of `val`. The trace captures every `text`, bloating it past the 16 MiB frame limit — so
+/// the response fails to send even though the returned value is tiny. Passes once the trace is
+/// size-bounded before transport.
+#[tokio::test]
+#[serial]
+async fn test_exec_large_trace_still_sends() {
+    // ~2 MiB per callback response × 10 calls ≈ 20 MiB of trace, over the 16 MiB frame limit.
+    const BIG_TEXT_BYTES: usize = 2 * 1024 * 1024;
+    const N_CALLS: i64 = 10;
+
+    let (session_id, server, _) = create_test_server_with_session().await;
+
+    // Register a single callback tool that returns a large { val, text } object.
+    let big_tool = CallbackConfig {
+        name: "get".into(),
+        namespace: Some("test_load".into()),
+        description: Some("Returns a large payload".into()),
+        input_schema: Some(json!({
+            "type": "object",
+            "properties": { "i": { "type": "number" } },
+            "required": ["i"]
+        })),
+        output_schema: Some(json!({
+            "type": "object",
+            "properties": {
+                "val": { "type": "number" },
+                "text": { "type": "string" }
+            },
+            "required": ["val", "text"]
+        })),
+    };
+    let register_res = server
+        .post("/register/tools")
+        .add_header(CODE_MODE_SESSION_HEADER, session_id.to_string())
+        .json(&json!({ "tools": [big_tool] }))
+        .await;
+    register_res.assert_status_ok();
+
+    let mut ws = connect_websocket(&server, session_id)
+        .await
+        .into_websocket()
+        .await;
+
+    // Script: call the tool N times, accumulate only the small `val`, return the sum.
+    let code = format!(
+        "async function run() {{
+            let sum = 0;
+            for (let i = 0; i < {N_CALLS}; i++) {{
+                const res = await invoke({{ name: \"test_load__get\", arguments: {{ i }} }});
+                sum += res.val;
+            }}
+            return sum;
+        }}"
+    );
+
+    ws.send_json(&json!({
+        "jsonrpc": "2.0",
+        "id": "test-large-trace",
+        "method": "execute_code",
+        "params": { "code": code, "disclosure": "sidecar" }
+    }))
+    .await;
+
+    // Service each execute_tool request with a large { val, text } response.
+    let big_text = "A".repeat(BIG_TEXT_BYTES);
+    for i in 0..N_CALLS {
+        let msg: WsJsonRpcMessage = ws.receive_json().await;
+        let (_req, req_id) = msg.into_request().unwrap();
+        ws.send_json(&json!({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": { "output": { "val": i, "text": big_text } }
+        }))
+        .await;
+    }
+
+    // The final execute_code response carries the ~20 MiB trace. Today this receive fails
+    // (message exceeds the receiver frame limit); after the trace is bounded it succeeds.
+    let response: serde_json::Value = ws.receive_json().await;
+
+    let expected_sum: i64 = (0..N_CALLS).sum();
+    assert_eq!(response["result"]["output"], json!(expected_sum));
+}
+
 #[tokio::test]
 #[serial]
 async fn test_exec_type_error_with_rich_diagnostics() {

--- a/plans/large-execution-payloads.md
+++ b/plans/large-execution-payloads.md
@@ -1,0 +1,56 @@
+# Large execution payloads over WebSocket
+
+## Problem
+`execute_code` responses are serialized to a **single WebSocket text frame** ([handler.rs](../crates/pctx_session_server/src/websocket/handler.rs)). That frame is bounded by tungstenite's **default 16 MiB `max_frame_size`** — enforced by the *receiver* (the client), not configured anywhere in this repo. Two ways to exceed it:
+
+- **Trace bloat:** every tool call's full output is cloned into `trace.events[].outcome.output` ([registry.rs:365](../crates/pctx_registry/src/registry.rs#L365)). A script that returns a tiny value but calls a tool with large results still produces a >16 MiB trace, and the whole response fails to send.
+- **Large return value / stdout:** the script itself returns or prints something huge.
+
+Either way the response silently fails to reach the client.
+
+## Current short-term solution (shipped)
+[`truncate::bound_response_size`](../crates/pctx_session_server/src/websocket/truncate.rs) shrinks an oversized response before it's sent, under a 15 MiB ceiling (`MAX_RESPONSE_BYTES`, margin under the 16 MiB frame limit):
+1. Drop the trace (the usual culprit).
+2. If still too large, replace the return value with a `{ "__truncated__": true, "reason": … }` marker and append the reason to `stderr`, so the calling agent knows data was dropped and why.
+
+This keeps every response deliverable but is **lossy** — the trace and large return values are discarded, not retrievable. The long-term goal is to deliver them without breaking the frame limit.
+
+---
+
+## Long-term options
+
+### A WebSocket fact worth knowing
+A WS *message* is already split into *frames* by the sender and reassembled by the receiver up to `max_message_size` (default **64 MiB**). The 16 MiB we hit is the per-*frame* cap; message cap is 64 MiB — both are just config. So "manual chunking" mostly reinvents what the protocol already does.
+
+### Two axes
+- **Delivery** — how the client gets the bytes: inline (bigger frames / compression) vs. **out-of-band** (return a reference/URL, client pulls).
+- **Storage** — where oversized bytes live: server memory, the session backend, or object storage.
+
+### Delivery options
+
+| Option | How | Pros | Cons |
+|---|---|---|---|
+| **A. Raise frame/message limits** | Set `WebSocketConfig` on `on_upgrade` ([handler.rs](../crates/pctx_session_server/src/websocket/handler.rs)) | ~1 line; buys headroom | Moves the ceiling, doesn't remove it; big frames = memory spikes + head-of-line blocking; **every client must raise its receive cap too** |
+| **B. Compress** | permessage-deflate WS extension, or app-level gzip | JSON compresses ~5-10×; transparent | Still bounded; CPU cost; no help for truly huge data |
+| **C. Out-of-band reference + fetch** | On overflow, persist the payload, return a small `{ ref }`; client fetches it separately (REST endpoint **or** presigned URL) | Hot path stays tiny; client pulls only when needed; scales to any size; covers `output` + trace | New endpoint/URL + client change; needs a storage layer + retention/GC; extra round-trip |
+| **D. Manual chunk + reassemble** | Split into N WS messages the client stitches | Stays on one channel | Reinvents WS framing; ordering/reassembly bugs — **not recommended** |
+
+### Storage layer for C
+`post_execution` ([handler.rs](../crates/pctx_session_server/src/websocket/handler.rs)) is only a hook — the deployed backend is **Redis** ([state/mod.rs:37](../crates/pctx_session_server/src/state/mod.rs#L37)), which is the wrong home for multi-MB blobs (memory pressure, value-size limits, eviction). C's reference indirection is cheap, but the *bytes* belong in a persistent blob layer:
+- **Object storage (S3/GCS)** — standard home; the reference is then a **presigned URL** (client downloads directly, server never re-streams) or an opaque id the server resolves.
+- A dedicated blob table/store if keeping it in-house.
+
+### Also worth considering
+- **Cap at the source.** Truncate/summarize each tool output *before* it enters the trace ([registry.rs:365](../crates/pctx_registry/src/registry.rs#L365)) — e.g. first N KB + `original_bytes`. Prevents bloat instead of transporting it. Cheapest durable fix; pairs with anything.
+- **Pull-based pagination.** Trace becomes N events fetched on demand (`GET /executions/{id}/trace?offset=`). Natural extension of C.
+- **Content-addressed dedup.** Store a recurring large blob once by hash, reference by id.
+
+---
+
+## Recommendation
+Cheapest-first, layered:
+1. **Ship the short-term bound** — done.
+2. **Cap tool outputs at the source** — kills the common cause with minimal surface.
+3. **Option C (out-of-band reference + fetch), backed by object storage** (not Redis) — return a presigned download URL for large payloads; covers oversized `output`/`stdout` as well as trace. Add **B (compression)** as a transparent multiplier for mid-size payloads.
+
+Skip **D** (manual chunking). Treat **A** (raising limits) as a temporary knob only, and remember every client must raise its cap too.


### PR DESCRIPTION
## Problem
`execute_code` responses are serialized to a single WebSocket text frame, bounded by tungstenite's default 16 MiB `max_frame_size` (enforced by the receiving client). Two ways to exceed it:

- **Trace bloat** — every tool call's full output is cloned into `trace.events[].outcome.output`, so a script returning a tiny value but calling a tool with large results still produces a >16 MiB trace.
- **Large return value / stdout** — the script itself returns or prints something huge.

Either way the response silently fails to reach the client. Reproduced by `test_exec_large_trace_still_sends`.

## Short-term fix (this PR)
New `truncate::bound_response_size` shrinks an oversized response before it's sent, under a 15 MiB ceiling (`MAX_RESPONSE_BYTES`, margin under the 16 MiB frame limit):
1. Drop the trace (the usual culprit).
2. If still too large, replace the return value with a `{ "__truncated__": true, "reason": … }` marker and append the reason to `stderr`, so the calling agent knows data was dropped and why.

This keeps every response deliverable. It's lossy by design — the durable fix is tracked separately.

## Changes
- `crates/pctx_session_server/src/websocket/truncate.rs` — new bounding module.
- `crates/pctx_session_server/src/websocket/handler.rs` — call `bound_response_size` before sending; removed the stale `// TEST only` trace-blanking line.
- `crates/pctx_session_server/tests/executions.rs` — `test_exec_large_trace_still_sends` now passes; new `test_exec_large_output_truncates_and_sends` covers the oversized-return-value path.
- `plans/large-execution-payloads.md` — problem writeup, the shipped short-term fix, and long-term options (out-of-band reference + object storage, compression, cap-at-source; not manual chunking).

## Testing
`cargo test -p pctx_session_server` — 11 passing. `cargo clippy -p pctx_session_server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)