### PR TITLE
ci: dispatch pctx-helm version sync after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,3 +391,13 @@ jobs:
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+
+  custom-sync-helm:
+    needs:
+      - plan
+      - announce
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/sync-helm.yaml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/.github/workflows/sync-helm.yaml
+++ b/.github/workflows/sync-helm.yaml
@@ -1,0 +1,23 @@
+name: sync-helm
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch sync-pctx-version
+        env:
+          GH_TOKEN: ${{ secrets.HELM_SYNC_TOKEN }}
+          VERSION: ${{ fromJson(inputs.plan).announcement_tag }}
+        run: |
+          gh workflow run sync-pctx-version.yaml \
+            --repo ${{ secrets.HELM_REPO }} \
+            --field version="$VERSION"


### PR DESCRIPTION
Adds a post-announce job to the release pipeline that dispatches pctx-helm's `sync-pctx-version` workflow with the released tag, so the chart's pctx pin gets a bump PR automatically once a release is published.

- `sync-helm.yaml`: reusable (`workflow_call`-only) workflow that runs the cross-repo dispatch. `permissions: {}`; the tag is passed via env var, not shell interpolation.
- `release.yml`: `custom-sync-helm` job after `announce`, following cargo-dist's post-announce custom-job shape. Prerelease-guarded like the other publish jobs, so beta tags don't dispatch.

An `on: release` workflow wouldn't work here: the release is created with the default `GITHUB_TOKEN`, whose events don't trigger workflows.