### PR TITLE
ci: pass --ref to helm sync dispatch

### DIFF
--- a/.github/workflows/sync-helm.yaml
+++ b/.github/workflows/sync-helm.yaml
@@ -20,4 +20,5 @@ jobs:
         run: |
           gh workflow run sync-pctx-version.yaml \
             --repo ${{ secrets.HELM_REPO }} \
+            --ref main \
             --field version="$VERSION"


### PR DESCRIPTION
Without an explicit `--ref`, `gh workflow run` looks up the target repo's default branch first, which the workflow's token can't do. Pass the ref so the dispatch call is made directly.