### PR TITLE
fix: raise rmcp minimum to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Declared `rmcp` minimum raised from 1.2.0 to 1.8.0, the version the code
+  actually requires. With the understated minimum, downstream consumers of the
+  git-dep crates could resolve an older rmcp and fail to compile
+  `pctx_session_server`.
+
 ## [v0.7.3] - 2026-07-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tower-http = "0.6"
 utoipa = "5"
 
 # MCP
-rmcp = "1.2.0"
+rmcp = "1.8.0"
 reqwest = { version = "0.13.2", default-features = false }
 
 # Logging & Telemetry


### PR DESCRIPTION
The workspace declared `rmcp = "1.2.0"` but the code uses APIs that changed by 1.8 (`ErrorData`/`RequestId` signatures), so any consumer resolving an older 1.x fails to compile `pctx_session_server` (E0308). Our own lockfile already resolves 1.8.0; this makes the declared minimum match reality so downstream `cargo update` is forced onto a working version.