### PR TITLE
fix(executor): isolate per-tool registration failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `/register/tools` responses now include `warnings`: tools that registered in a degraded form, with the reason. A tool whose JSON Schema our codegen cannot express is registered with a permissive `any` signature so it stays callable; previously that only reached the server logs, invisible to a client talking to a remotely deployed session server.
+
 ### Changed
+
+- **Breaking:** `CodeMode::with_callbacks` returns `(Self, CallbackReport)` instead of `Result<Self>`, so builder-style callers see which tools failed or degraded. Per-tool isolation means the batch itself cannot fail, so the report is the only outcome.
+- **Breaking:** `CodeMode::add_callback` returns `Result<Vec<String>>` — the reasons that tool's types were degraded to `any`, empty when fully typed.
 
 ### Fixed
 
+- `/register/tools` no longer fails the whole batch when a single tool cannot be registered. Each tool is registered independently: a genuinely bad tool (name clash, unparseable schema) is skipped and returned in the response's `failed` list, and a tool our codegen cannot type degrades to an `any` signature rather than being dropped. Previously one bad tool from an upstream server — such as a recursive `$ref` in a federated schema — took down registration for the entire batch, forcing clients into ~135 sequential per-tool calls per session.
 - Declared `rmcp` minimum raised from 1.2.0 to 1.8.0, the version the code
   actually requires. With the understated minimum, downstream consumers of the
   git-dep crates could resolve an older rmcp and fail to compile

--- a/crates/pctx/src/commands/mcp/dev/mod.rs
+++ b/crates/pctx/src/commands/mcp/dev/mod.rs
@@ -565,8 +565,7 @@ mod tests {
                 }))
                 .unwrap(),
                 Some(serde_json::from_value(account_schema.clone()).unwrap()),
-            )
-            .unwrap(),
+            ),
             Tool::new(
                 "freeze_account",
                 Some("Freezes an account".into()),
@@ -579,8 +578,7 @@ mod tests {
                 }))
                 .unwrap(),
                 Some(serde_json::from_value(account_schema.clone()).unwrap()),
-            )
-            .unwrap(),
+            ),
         ];
 
         let mut cm = CodeMode::default();

--- a/crates/pctx_code_mode/src/code_mode.rs
+++ b/crates/pctx_code_mode/src/code_mode.rs
@@ -12,8 +12,9 @@ use tracing::{debug, info, instrument, warn};
 use crate::{
     Error, Result,
     model::{
-        CallbackConfig, ExecuteBashOutput, ExecuteTypescriptOutput, FunctionDetails,
-        GetFunctionDetailsInput, GetFunctionDetailsOutput, ListFunctionsOutput, ListedFunction,
+        CallbackConfig, CallbackReport, ExecuteBashOutput, ExecuteTypescriptOutput, FailedCallback,
+        FunctionDetails, GetFunctionDetailsInput, GetFunctionDetailsOutput, ListFunctionsOutput,
+        ListedFunction,
     },
 };
 
@@ -56,7 +57,7 @@ impl CodeMode {
         mut self,
         callbacks: impl IntoIterator<Item = &'a CallbackConfig>,
     ) -> Result<Self> {
-        self.add_callbacks(callbacks)?;
+        self.add_callbacks(callbacks);
         Ok(self)
     }
 
@@ -154,17 +155,12 @@ impl CodeMode {
                 None
             };
 
-            tools.push(
-                Tool::new(
-                    &mcp_tool.name,
-                    mcp_tool.description.clone().map(String::from),
-                    Some(input_schema),
-                    output_schema,
-                )
-                .map_err(|e| {
-                    Error::Message(format!("Failed to create tool `{}`: {e}", &mcp_tool.name))
-                })?,
-            );
+            tools.push(Tool::new(
+                &mcp_tool.name,
+                mcp_tool.description.clone().map(String::from),
+                Some(input_schema),
+                output_schema,
+            ));
         }
 
         let description = mcp_client
@@ -183,14 +179,33 @@ impl CodeMode {
         Ok((tool_set, server.clone()))
     }
 
+    /// Register a batch of callback tools, isolating per-tool failures.
+    ///
+    /// Each tool is registered independently. A tool that cannot be registered
+    /// (name clash, unparseable schema) is skipped and recorded in the returned
+    /// [`CallbackReport`] without affecting the rest of the batch.
     pub fn add_callbacks<'a>(
         &mut self,
         callbacks: impl IntoIterator<Item = &'a CallbackConfig>,
-    ) -> Result<()> {
+    ) -> CallbackReport {
+        let mut report = CallbackReport::default();
         for callback in callbacks {
-            self.add_callback(callback)?;
+            match self.add_callback(callback) {
+                Ok(()) => report.registered.push(callback.id()),
+                Err(e) => {
+                    warn!(
+                        tool = %callback.id(),
+                        error = %e,
+                        "code mode: skipping tool that failed to register",
+                    );
+                    report.failed.push(FailedCallback {
+                        id: callback.id(),
+                        reason: e.to_string(),
+                    });
+                }
+            }
         }
-        Ok(())
+        report
     }
 
     // Generates a Tool and add it to the correct Toolset from the given callback config
@@ -245,7 +260,7 @@ impl CodeMode {
             callback.description.clone(),
             input_schema,
             output_schema,
-        )?;
+        );
 
         // add tool & it's configuration
         tool_set.tools.push(tool);
@@ -686,5 +701,44 @@ export default result;"#,
             registry: execution_res.registry,
             trace: execution_res.trace,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallbackConfig;
+
+    fn cb(name: &str) -> CallbackConfig {
+        CallbackConfig {
+            name: name.to_string(),
+            namespace: Some("ns".to_string()),
+            description: None,
+            input_schema: None,
+            output_schema: None,
+        }
+    }
+
+    /// A failing tool in a batch is isolated: the others still register and the
+    /// offender is reported rather than failing the call (pctx#119).
+    #[test]
+    fn add_callbacks_isolates_a_failing_tool() {
+        let mut cm = CodeMode::default();
+        // The second `dup` clashes with the first; `keep` is unrelated.
+        let batch = vec![cb("keep"), cb("dup"), cb("dup")];
+
+        let report = cm.add_callbacks(&batch);
+
+        assert_eq!(report.registered, vec!["ns__keep", "ns__dup"]);
+        assert_eq!(report.failed.len(), 1);
+        assert_eq!(report.failed[0].id, "ns__dup");
+
+        // The good tools are actually registered despite the clash.
+        let names: Vec<String> = cm
+            .tool_sets
+            .iter()
+            .flat_map(|ts| ts.tools.iter().map(|t| t.name.clone()))
+            .collect();
+        assert_eq!(names, vec!["keep".to_string(), "dup".to_string()]);
     }
 }

--- a/crates/pctx_code_mode/src/code_mode.rs
+++ b/crates/pctx_code_mode/src/code_mode.rs
@@ -12,9 +12,9 @@ use tracing::{debug, info, instrument, warn};
 use crate::{
     Error, Result,
     model::{
-        CallbackConfig, CallbackReport, ExecuteBashOutput, ExecuteTypescriptOutput, FailedCallback,
-        FunctionDetails, GetFunctionDetailsInput, GetFunctionDetailsOutput, ListFunctionsOutput,
-        ListedFunction,
+        CallbackConfig, CallbackReport, CallbackWarning, ExecuteBashOutput,
+        ExecuteTypescriptOutput, FailedCallback, FunctionDetails, GetFunctionDetailsInput,
+        GetFunctionDetailsOutput, ListFunctionsOutput, ListedFunction,
     },
 };
 
@@ -53,12 +53,17 @@ impl CodeMode {
         Ok(self)
     }
 
+    /// Register a batch of callback tools, returning the [`CallbackReport`]
+    /// alongside the updated `CodeMode`.
+    ///
+    /// Registration is per-tool and never fails the batch, so this is
+    /// infallible; inspect the report to see what was dropped or degraded.
     pub fn with_callbacks<'a>(
         mut self,
         callbacks: impl IntoIterator<Item = &'a CallbackConfig>,
-    ) -> Result<Self> {
-        self.add_callbacks(callbacks);
-        Ok(self)
+    ) -> (Self, CallbackReport) {
+        let report = self.add_callbacks(callbacks);
+        (self, report)
     }
 
     // --------------- Registrations functions ---------------
@@ -183,7 +188,9 @@ impl CodeMode {
     ///
     /// Each tool is registered independently. A tool that cannot be registered
     /// (name clash, unparseable schema) is skipped and recorded in the returned
-    /// [`CallbackReport`] without affecting the rest of the batch.
+    /// [`CallbackReport`] without affecting the rest of the batch. A tool that
+    /// registers in a degraded form (types codegen could not express, so `any`)
+    /// is recorded in the report's `warnings`.
     pub fn add_callbacks<'a>(
         &mut self,
         callbacks: impl IntoIterator<Item = &'a CallbackConfig>,
@@ -191,7 +198,15 @@ impl CodeMode {
         let mut report = CallbackReport::default();
         for callback in callbacks {
             match self.add_callback(callback) {
-                Ok(()) => report.registered.push(callback.id()),
+                Ok(degraded) => {
+                    report.registered.push(callback.id());
+                    report
+                        .warnings
+                        .extend(degraded.into_iter().map(|reason| CallbackWarning {
+                            id: callback.id(),
+                            reason,
+                        }));
+                }
                 Err(e) => {
                     warn!(
                         tool = %callback.id(),
@@ -208,8 +223,11 @@ impl CodeMode {
         report
     }
 
-    // Generates a Tool and add it to the correct Toolset from the given callback config
-    pub fn add_callback(&mut self, callback: &CallbackConfig) -> Result<()> {
+    /// Generates a Tool and adds it to the correct Toolset from the given callback config.
+    ///
+    /// Returns the reasons, if any, the tool's types had to be degraded to `any`
+    /// — the tool is still registered and callable.
+    pub fn add_callback(&mut self, callback: &CallbackConfig) -> Result<Vec<String>> {
         debug!(callback =? callback.id(), "Adding callback tool {}", callback.id());
 
         // find the correct toolset & check for clashes
@@ -261,13 +279,14 @@ impl CodeMode {
             input_schema,
             output_schema,
         );
+        let degraded = tool.degraded_types().to_vec();
 
         // add tool & it's configuration
         tool_set.tools.push(tool);
         self.callbacks.push(callback.clone());
         self.refresh_virtual_fs();
 
-        Ok(())
+        Ok(degraded)
     }
 
     pub fn add_tool_set(&mut self, tool_set: ToolSet) -> Result<()> {
@@ -740,5 +759,26 @@ mod tests {
             .flat_map(|ts| ts.tools.iter().map(|t| t.name.clone()))
             .collect();
         assert_eq!(names, vec!["keep".to_string(), "dup".to_string()]);
+        assert!(report.warnings.is_empty());
+    }
+
+    /// A tool whose schema codegen can't express still registers, but the
+    /// degradation is reported so a remote caller sees it too.
+    #[test]
+    fn add_callbacks_reports_degraded_types() {
+        let mut cm = CodeMode::default();
+        let mut degraded = cb("degraded");
+        degraded.input_schema = Some(json!({
+            "type": "object",
+            "properties": { "x": { "$ref": "#/definitions/DoesNotExist" } }
+        }));
+
+        let report = cm.add_callbacks(&[cb("fine"), degraded]);
+
+        assert_eq!(report.registered, vec!["ns__fine", "ns__degraded"]);
+        assert!(report.failed.is_empty());
+        assert_eq!(report.warnings.len(), 1);
+        assert_eq!(report.warnings[0].id, "ns__degraded");
+        assert!(report.warnings[0].reason.contains("degraded to `any`"));
     }
 }

--- a/crates/pctx_code_mode/src/model.rs
+++ b/crates/pctx_code_mode/src/model.rs
@@ -233,3 +233,22 @@ impl CallbackConfig {
         )
     }
 }
+
+/// Outcome of registering a batch of callback tools.
+///
+/// Tools that register are listed in `registered`; those that cannot be are
+/// collected in `failed`. Each tool is registered independently, so one
+/// failure does not affect another.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct CallbackReport {
+    /// Ids of tools that registered (including any degraded to an `any` type).
+    pub registered: Vec<String>,
+    /// Tools that could not be registered at all, with the reason.
+    pub failed: Vec<FailedCallback>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FailedCallback {
+    pub id: String,
+    pub reason: String,
+}

--- a/crates/pctx_code_mode/src/model.rs
+++ b/crates/pctx_code_mode/src/model.rs
@@ -239,16 +239,30 @@ impl CallbackConfig {
 /// Tools that register are listed in `registered`; those that cannot be are
 /// collected in `failed`. Each tool is registered independently, so one
 /// failure does not affect another.
+///
+/// A tool whose schema codegen cannot express still registers, with a
+/// permissive `any` signature, and is reported in `warnings` — so a remote
+/// caller learns about the degradation instead of it only reaching the logs.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct CallbackReport {
     /// Ids of tools that registered (including any degraded to an `any` type).
     pub registered: Vec<String>,
     /// Tools that could not be registered at all, with the reason.
     pub failed: Vec<FailedCallback>,
+    /// Tools that registered, but not as specified (e.g. types degraded to `any`).
+    #[serde(default)]
+    pub warnings: Vec<CallbackWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct FailedCallback {
+    pub id: String,
+    pub reason: String,
+}
+
+/// A tool that registered successfully but in a degraded form.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CallbackWarning {
     pub id: String,
     pub reason: String,
 }

--- a/crates/pctx_codegen/src/tools.rs
+++ b/crates/pctx_codegen/src/tools.rs
@@ -1,14 +1,31 @@
 use schemars::schema::RootSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{
-    CodegenResult,
     case::Case,
     ts_generate_docstring,
     typegen::{TypegenResult, generate_types},
 };
+
+/// Generate the TypeScript type for a tool schema, falling back to `any` when
+/// codegen cannot express the schema.
+///
+/// Upstream tools may carry JSON Schema this codegen does not support (for
+/// example a recursive `$ref`). Such a tool is given a permissive `any`
+/// signature so it remains callable at runtime, rather than being rejected.
+fn generate_types_lenient(schema: RootSchema, type_name: &str, tool: &str) -> TypegenResult {
+    generate_types(schema, type_name).unwrap_or_else(|e| {
+        warn!(tool, type_name, error = %e, "codegen failed; degrading tool type to `any`");
+        TypegenResult {
+            types_generated: 0,
+            type_signature: "any".into(),
+            all_optional: false,
+            types: String::new(),
+        }
+    })
+}
 
 pub const DEFAULT_NAMESPACE: &str = "Tools";
 
@@ -100,23 +117,18 @@ impl Tool {
         description: Option<String>,
         input: Option<RootSchema>,
         output: Option<RootSchema>,
-    ) -> CodegenResult<Self> {
+    ) -> Self {
         let fn_name = Case::Camel.sanitize(name);
         debug!("Generating Typescript interface for tool: '{name}' -> function {fn_name}",);
 
-        let input_type = if let Some(i) = &input {
-            Some(generate_types(i.clone(), &format!("{fn_name}Input"))?)
-        } else {
-            None
-        };
+        let input_type = input
+            .as_ref()
+            .map(|i| generate_types_lenient(i.clone(), &format!("{fn_name}Input"), name));
+        let output_type = output
+            .as_ref()
+            .map(|o| generate_types_lenient(o.clone(), &format!("{fn_name}Output"), name));
 
-        let output_type = if let Some(o) = output.clone() {
-            Some(generate_types(o, &format!("{fn_name}Output"))?)
-        } else {
-            None
-        };
-
-        Ok(Self {
+        Self {
             name: name.into(),
             description,
             input_schema: input,
@@ -124,7 +136,7 @@ impl Tool {
             fn_name,
             input_type,
             output_type,
-        })
+        }
     }
 
     pub fn id(&self, toolset_name: Option<&str>) -> String {

--- a/crates/pctx_codegen/src/tools.rs
+++ b/crates/pctx_codegen/src/tools.rs
@@ -15,16 +15,29 @@ use crate::{
 /// Upstream tools may carry JSON Schema this codegen does not support (for
 /// example a recursive `$ref`). Such a tool is given a permissive `any`
 /// signature so it remains callable at runtime, rather than being rejected.
-fn generate_types_lenient(schema: RootSchema, type_name: &str, tool: &str) -> TypegenResult {
-    generate_types(schema, type_name).unwrap_or_else(|e| {
-        warn!(tool, type_name, error = %e, "codegen failed; degrading tool type to `any`");
-        TypegenResult {
-            types_generated: 0,
-            type_signature: "any".into(),
-            all_optional: false,
-            types: String::new(),
+///
+/// Returns the type alongside a human readable reason when the type was
+/// degraded, so callers can report it rather than only logging it.
+fn generate_types_lenient(
+    schema: RootSchema,
+    type_name: &str,
+    tool: &str,
+) -> (TypegenResult, Option<String>) {
+    match generate_types(schema, type_name) {
+        Ok(result) => (result, None),
+        Err(e) => {
+            warn!(tool, type_name, error = %e, "codegen failed; degrading tool type to `any`");
+            (
+                TypegenResult {
+                    types_generated: 0,
+                    type_signature: "any".into(),
+                    all_optional: false,
+                    types: String::new(),
+                },
+                Some(e.to_string()),
+            )
         }
-    })
+    }
 }
 
 pub const DEFAULT_NAMESPACE: &str = "Tools";
@@ -109,6 +122,11 @@ pub struct Tool {
 
     input_type: Option<TypegenResult>,
     output_type: Option<TypegenResult>,
+
+    /// Reasons the tool's types were degraded to `any`, one per schema that
+    /// codegen could not express. Empty for a fully typed tool.
+    #[serde(default)]
+    degraded_types: Vec<String>,
 }
 
 impl Tool {
@@ -121,12 +139,24 @@ impl Tool {
         let fn_name = Case::Camel.sanitize(name);
         debug!("Generating Typescript interface for tool: '{name}' -> function {fn_name}",);
 
-        let input_type = input
-            .as_ref()
-            .map(|i| generate_types_lenient(i.clone(), &format!("{fn_name}Input"), name));
-        let output_type = output
-            .as_ref()
-            .map(|o| generate_types_lenient(o.clone(), &format!("{fn_name}Output"), name));
+        let mut degraded_types = vec![];
+
+        let input_type = input.as_ref().map(|i| {
+            let (ty, degraded) =
+                generate_types_lenient(i.clone(), &format!("{fn_name}Input"), name);
+            if let Some(reason) = degraded {
+                degraded_types.push(format!("input schema degraded to `any`: {reason}"));
+            }
+            ty
+        });
+        let output_type = output.as_ref().map(|o| {
+            let (ty, degraded) =
+                generate_types_lenient(o.clone(), &format!("{fn_name}Output"), name);
+            if let Some(reason) = degraded {
+                degraded_types.push(format!("output schema degraded to `any`: {reason}"));
+            }
+            ty
+        });
 
         Self {
             name: name.into(),
@@ -136,7 +166,15 @@ impl Tool {
             fn_name,
             input_type,
             output_type,
+            degraded_types,
         }
+    }
+
+    /// Reasons this tool's types were degraded to `any` during codegen.
+    ///
+    /// Empty when both schemas generated real TypeScript types.
+    pub fn degraded_types(&self) -> &[String] {
+        &self.degraded_types
     }
 
     pub fn id(&self, toolset_name: Option<&str>) -> String {

--- a/crates/pctx_codegen/tests/tool.rs
+++ b/crates/pctx_codegen/tests/tool.rs
@@ -97,4 +97,21 @@ fn tool_degrades_uncodegenable_schema_to_any() {
     let tool = Tool::new("bad_tool", None, Some(bad), None);
 
     assert_eq!(tool.input_signature().as_deref(), Some("any"));
+    // The degradation is reported, not just logged, so callers can surface it.
+    assert_eq!(tool.degraded_types().len(), 1);
+    assert!(tool.degraded_types()[0].starts_with("input schema degraded to `any`"));
+}
+
+/// A tool whose schemas all generate real types reports no degradation.
+#[test]
+fn tool_with_generatable_schema_reports_no_degradation() {
+    let good: RootSchema = serde_json::from_value(json!({
+        "type": "object",
+        "properties": { "x": { "type": "string" } }
+    }))
+    .unwrap();
+
+    let tool = Tool::new("good_tool", None, Some(good), None);
+
+    assert!(tool.degraded_types().is_empty());
 }

--- a/crates/pctx_codegen/tests/tool.rs
+++ b/crates/pctx_codegen/tests/tool.rs
@@ -1,6 +1,7 @@
 use pctx_codegen::{RootSchema, Tool, ToolSet};
 use pctx_type_check_runtime::type_check;
 use serde::Deserialize;
+use serde_json::json;
 
 const BASIC_TOOL: &str = include_str!("./fixtures/tools/basic.yml");
 const NESTED_TYPES_TOOL: &str = include_str!("./fixtures/tools/nested_types.yml");
@@ -25,7 +26,6 @@ impl ToolFixture {
             self.input_schema.clone(),
             self.output_schema.clone(),
         )
-        .expect("Tool::new failed")
     }
 }
 
@@ -79,4 +79,22 @@ fn test_toolset_namespace() {
         "toolset__namespace_interface.ts",
         toolset.ts_namespace_declaration(true)
     );
+}
+
+// --- codegen resilience ---
+
+/// A schema our codegen can't express (here, a `$ref` to a missing definition)
+/// must not fail the tool: it degrades to a permissive `any` signature so the
+/// tool stays callable at runtime, just untyped.
+#[test]
+fn tool_degrades_uncodegenable_schema_to_any() {
+    let bad: RootSchema = serde_json::from_value(json!({
+        "type": "object",
+        "properties": { "x": { "$ref": "#/definitions/DoesNotExist" } }
+    }))
+    .unwrap();
+
+    let tool = Tool::new("bad_tool", None, Some(bad), None);
+
+    assert_eq!(tool.input_signature().as_deref(), Some("any"));
 }

--- a/crates/pctx_session_server/openapi.json
+++ b/crates/pctx_session_server/openapi.json
@@ -508,6 +508,21 @@
           }
         }
       },
+      "FailedCallback": {
+        "type": "object",
+        "required": [
+          "id",
+          "reason"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
       "FunctionDetails": {
         "allOf": [
           {
@@ -679,11 +694,17 @@
       },
       "RegisterToolsResponse": {
         "type": "object",
-        "description": "Response to registering tools",
+        "description": "Response to registering tools.\n\n`failed` lists tools that could not be registered at all (name clash,\nunparseable schema); the rest of the batch still registers. A tool whose\nschema our codegen can't express is registered with a permissive `any`\nsignature, not failed.",
         "required": [
           "registered"
         ],
         "properties": {
+          "failed": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FailedCallback"
+            }
+          },
           "registered": {
             "type": "integer",
             "minimum": 0

--- a/crates/pctx_session_server/openapi.json
+++ b/crates/pctx_session_server/openapi.json
@@ -422,6 +422,22 @@
           "output_schema": {}
         }
       },
+      "CallbackWarning": {
+        "type": "object",
+        "description": "A tool that registered successfully but in a degraded form.",
+        "required": [
+          "id",
+          "reason"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
       "CloseSessionResponse": {
         "type": "object",
         "description": "Response after closing a `CodeMode` session",
@@ -694,7 +710,7 @@
       },
       "RegisterToolsResponse": {
         "type": "object",
-        "description": "Response to registering tools.\n\n`failed` lists tools that could not be registered at all (name clash,\nunparseable schema); the rest of the batch still registers. A tool whose\nschema our codegen can't express is registered with a permissive `any`\nsignature, not failed.",
+        "description": "Response to registering tools.\n\n`failed` lists tools that could not be registered at all (name clash,\nunparseable schema); the rest of the batch still registers. A tool whose\nschema our codegen can't express is registered with a permissive `any`\nsignature and reported in `warnings`, not failed.",
         "required": [
           "registered"
         ],
@@ -708,6 +724,13 @@
           "registered": {
             "type": "integer",
             "minimum": 0
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallbackWarning"
+            },
+            "description": "Tools that registered in a degraded form (e.g. types fell back to `any`)."
           }
         }
       }

--- a/crates/pctx_session_server/src/model.rs
+++ b/crates/pctx_session_server/src/model.rs
@@ -85,12 +85,15 @@ pub struct RegisterToolsRequest {
 /// `failed` lists tools that could not be registered at all (name clash,
 /// unparseable schema); the rest of the batch still registers. A tool whose
 /// schema our codegen can't express is registered with a permissive `any`
-/// signature, not failed.
+/// signature and reported in `warnings`, not failed.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegisterToolsResponse {
     pub registered: usize,
     #[serde(default)]
     pub failed: Vec<pctx_code_mode::model::FailedCallback>,
+    /// Tools that registered in a degraded form (e.g. types fell back to `any`).
+    #[serde(default)]
+    pub warnings: Vec<pctx_code_mode::model::CallbackWarning>,
 }
 
 /// Request to register MCP servers

--- a/crates/pctx_session_server/src/model.rs
+++ b/crates/pctx_session_server/src/model.rs
@@ -80,10 +80,17 @@ pub struct RegisterToolsRequest {
     pub tools: Vec<pctx_code_mode::model::CallbackConfig>,
 }
 
-/// Response to registering tools
+/// Response to registering tools.
+///
+/// `failed` lists tools that could not be registered at all (name clash,
+/// unparseable schema); the rest of the batch still registers. A tool whose
+/// schema our codegen can't express is registered with a permissive `any`
+/// signature, not failed.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegisterToolsResponse {
     pub registered: usize,
+    #[serde(default)]
+    pub failed: Vec<pctx_code_mode::model::FailedCallback>,
 }
 
 /// Request to register MCP servers

--- a/crates/pctx_session_server/src/routes.rs
+++ b/crates/pctx_session_server/src/routes.rs
@@ -8,7 +8,7 @@ use pctx_code_mode::{
         GetFunctionDetailsOutput, ListFunctionsOutput,
     },
 };
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::extractors::CodeModeSession;
@@ -249,21 +249,31 @@ pub(crate) async fn register_tools<B: PctxSessionBackend>(
                 details: None,
             },
         ))?;
-    code_mode
-        .add_callbacks(&request.tools)
-        .context("Failed adding callbacks")?;
+    // Register tools independently: a tool that cannot be registered is
+    // skipped and returned in `failed`, without failing the whole request.
+    let report = code_mode.add_callbacks(&request.tools);
 
     // Update the backend with the modified CodeMode
     state.backend.update(session_id, code_mode).await?;
 
-    info!(
-        session_id =? session_id,
-        tools =? &tool_ids,
-        "Registered tools",
-    );
+    if report.failed.is_empty() {
+        info!(
+            session_id =? session_id,
+            registered = report.registered.len(),
+            "Registered tools",
+        );
+    } else {
+        warn!(
+            session_id =? session_id,
+            registered = report.registered.len(),
+            failed =? report.failed,
+            "Registered tools; some were dropped",
+        );
+    }
 
     Ok(Json(RegisterToolsResponse {
-        registered: request.tools.len(),
+        registered: report.registered.len(),
+        failed: report.failed,
     }))
 }
 

--- a/crates/pctx_session_server/src/routes.rs
+++ b/crates/pctx_session_server/src/routes.rs
@@ -256,7 +256,7 @@ pub(crate) async fn register_tools<B: PctxSessionBackend>(
     // Update the backend with the modified CodeMode
     state.backend.update(session_id, code_mode).await?;
 
-    if report.failed.is_empty() {
+    if report.failed.is_empty() && report.warnings.is_empty() {
         info!(
             session_id =? session_id,
             registered = report.registered.len(),
@@ -267,13 +267,15 @@ pub(crate) async fn register_tools<B: PctxSessionBackend>(
             session_id =? session_id,
             registered = report.registered.len(),
             failed =? report.failed,
-            "Registered tools; some were dropped",
+            warnings =? report.warnings,
+            "Registered tools; some were dropped or degraded",
         );
     }
 
     Ok(Json(RegisterToolsResponse {
         registered: report.registered.len(),
         failed: report.failed,
+        warnings: report.warnings,
     }))
 }
 

--- a/crates/pctx_session_server/src/server.rs
+++ b/crates/pctx_session_server/src/server.rs
@@ -24,8 +24,8 @@ use crate::{
     routes, websocket,
 };
 use pctx_code_mode::model::{
-    CallbackConfig, ExecuteBashInput, ExecuteBashOutput, FunctionDetails, GetFunctionDetailsInput,
-    GetFunctionDetailsOutput, ListFunctionsOutput, ListedFunction,
+    CallbackConfig, ExecuteBashInput, ExecuteBashOutput, FailedCallback, FunctionDetails,
+    GetFunctionDetailsInput, GetFunctionDetailsOutput, ListFunctionsOutput, ListedFunction,
 };
 
 #[derive(OpenApi)]
@@ -60,6 +60,7 @@ use pctx_code_mode::model::{
             RegisterToolsRequest,
             CallbackConfig,
             RegisterToolsResponse,
+            FailedCallback,
             // Server registration
             RegisterMcpServersRequest,
             RegisterMcpServersResponse,

--- a/crates/pctx_session_server/src/server.rs
+++ b/crates/pctx_session_server/src/server.rs
@@ -24,8 +24,9 @@ use crate::{
     routes, websocket,
 };
 use pctx_code_mode::model::{
-    CallbackConfig, ExecuteBashInput, ExecuteBashOutput, FailedCallback, FunctionDetails,
-    GetFunctionDetailsInput, GetFunctionDetailsOutput, ListFunctionsOutput, ListedFunction,
+    CallbackConfig, CallbackWarning, ExecuteBashInput, ExecuteBashOutput, FailedCallback,
+    FunctionDetails, GetFunctionDetailsInput, GetFunctionDetailsOutput, ListFunctionsOutput,
+    ListedFunction,
 };
 
 #[derive(OpenApi)]
@@ -61,6 +62,7 @@ use pctx_code_mode::model::{
             CallbackConfig,
             RegisterToolsResponse,
             FailedCallback,
+            CallbackWarning,
             // Server registration
             RegisterMcpServersRequest,
             RegisterMcpServersResponse,

--- a/crates/pctx_session_server/tests/registrations.rs
+++ b/crates/pctx_session_server/tests/registrations.rs
@@ -35,7 +35,7 @@ async fn test_register_tools() {
         .await;
 
     res.assert_status_ok();
-    res.assert_json(&json!({"registered": test_tools.len()}));
+    res.assert_json(&json!({"registered": test_tools.len(), "failed": []}));
 
     // List functions & get details
     let list_res = server
@@ -123,7 +123,7 @@ async fn test_register_tools_not_shared() {
         .await;
 
     res.assert_status_ok();
-    res.assert_json(&json!({"registered": test_tools.len()}));
+    res.assert_json(&json!({"registered": test_tools.len(), "failed": []}));
 
     let session_2 = create_session(&server).await;
 

--- a/crates/pctx_session_server/tests/registrations.rs
+++ b/crates/pctx_session_server/tests/registrations.rs
@@ -35,7 +35,7 @@ async fn test_register_tools() {
         .await;
 
     res.assert_status_ok();
-    res.assert_json(&json!({"registered": test_tools.len(), "failed": []}));
+    res.assert_json(&json!({"registered": test_tools.len(), "failed": [], "warnings": []}));
 
     // List functions & get details
     let list_res = server
@@ -123,7 +123,7 @@ async fn test_register_tools_not_shared() {
         .await;
 
     res.assert_status_ok();
-    res.assert_json(&json!({"registered": test_tools.len(), "failed": []}));
+    res.assert_json(&json!({"registered": test_tools.len(), "failed": [], "warnings": []}));
 
     let session_2 = create_session(&server).await;
 


### PR DESCRIPTION
## Problem

`/register/tools` failed the **whole batch** when a single tool's schema couldn't be typed by our codegen (e.g. attio's recursive `$ref`). Since we federate arbitrary upstream JSON Schema, this fired constantly.

Measured in prod (7d, `gateway_calls` + Cloud Run logs): every code-mode session degraded to **~135 sequential per-tool `register/tools` calls (~6.4s, ~274 daily 500s)** instead of one batch call — all round-trips through the executor's public front door. Locally the same calls are localhost, so it only hurts in the cloud.

This is the #119 pattern one layer down: one bad actor takes down the rest.

## Fix — at the layer that owns the problem

- **Codegen never fails a tool over typing.** `Tool::new` is now infallible; `generate_types` failures degrade to a permissive `any` signature (with a `warn!`) so the tool stays callable, just untyped — never dropped.
- **Registration isolates per-tool.** `add_callbacks` returns a `CallbackReport { registered, failed, warnings }` instead of bubbling the first error. A genuinely bad tool (name clash, unparseable schema) is skipped and reported; the batch never aborts. The handler returns `200` with the report, never `500` on one bad tool.
- **Degradation is reported, not just logged.** A tool that fell back to `any` is listed in the report's `warnings` and returned in the `/register/tools` response, so a client talking to a remotely deployed session server learns its tool lost its types instead of that fact living only in our logs.

### API changes

- `CodeMode::with_callbacks` returns `(Self, CallbackReport)` — previously it discarded the report, hiding failures and warnings from builder-style callers. Infallible now: per-tool isolation means the batch cannot fail, so the report is the only outcome. **Breaking**; no in-repo callers.
- `CodeMode::add_callback` returns `Result<Vec<String>>` — the reasons that tool's types were degraded (empty when fully typed).
- `RegisterToolsResponse` gains `warnings: Vec<CallbackWarning { id, reason }>`; `openapi.json` regenerated.

## Why this fixes prod on its own

The portal's existing `register_resilient` sends the batch first — that batch now **succeeds**, so its per-tool fallback never triggers. The ~135 calls collapse to **one successful batch call, with no portal change required**. Deleting the portal-side `register_resilient` + `sanitize_input_schema` becomes a clean follow-up, not a prerequisite.

## Verification

- `cargo check --workspace` clean, `cargo fmt --check` clean, clippy-clean on touched files.
- New tests: `add_callbacks_isolates_a_failing_tool` (batch survives one bad tool), `add_callbacks_reports_degraded_types` (degraded tool registers *and* is reported), `tool_degrades_uncodegenable_schema_to_any` and `tool_with_generatable_schema_reports_no_degradation`. Existing `registrations.rs` expectations updated for the new `failed` field. All pass.

Refs #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
