### PR TITLE
fix(codegen): parenthesise union array items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Array items that are unions are now parenthesised: a nullable element generated `Foo | null[]`, binding the `[]` to `null`. ([#153](https://github.com/portofcontext/pctx/issues/153))
+
 ## [v0.7.4] - 2026-07-31
 
 ### Added

--- a/crates/pctx_codegen/src/schema_type.rs
+++ b/crates/pctx_codegen/src/schema_type.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt::Display;
 
 use schemars::schema::{
@@ -249,6 +250,39 @@ impl SchemaType {
         self.type_signature_inner(required, defs, ref_stack, 0)
     }
 
+    /// Follows `$ref` indirection until reaching a non-reference type, stopping at a
+    /// circular reference.
+    pub(crate) fn deref(&self, defs: &SchemaDefinitions) -> CodegenResult<SchemaType> {
+        let mut schema_type = self.clone();
+        let mut visited = HashSet::new();
+        while let SchemaType::Reference(ref_st) = &schema_type {
+            if !visited.insert(ref_st.ref_key.clone()) {
+                // circular ref
+                break;
+            }
+            let followed = ref_st.follow(defs)?;
+            schema_type = SchemaType::from(followed);
+        }
+
+        Ok(schema_type)
+    }
+
+    /// Whether the rendered signature is a top-level union, i.e. carries a `|` that is
+    /// not already enclosed by brackets or braces.
+    fn renders_union(&self, defs: &SchemaDefinitions) -> CodegenResult<bool> {
+        let resolved = self.deref(defs)?;
+        // `apply_optional_modifiers` appends `| null` to whatever the arm produced.
+        Ok(self.is_nullable()
+            || resolved.is_nullable()
+            || match &resolved {
+                SchemaType::Enum(EnumSchemaType { options, .. }) => options.len() > 1,
+                SchemaType::Union(UnionSchemaType { union_schemas, .. }) => union_schemas.len() > 1,
+                // Every other arm renders a single token, or one already delimited by
+                // `[]`/`{}`, so a nested `|` cannot escape it.
+                _ => false,
+            })
+    }
+
     fn type_signature_inner(
         &self,
         required: bool,
@@ -309,15 +343,16 @@ impl SchemaType {
                     depth + 1,
                 )?
             ),
-            SchemaType::Array(ArraySchemaType { item_schema, .. }) => format!(
-                "{item_sig}[]",
-                item_sig = SchemaType::from(item_schema).type_signature_inner(
-                    true,
-                    defs,
-                    ref_stack,
-                    depth + 1,
-                )?
-            ),
+            SchemaType::Array(ArraySchemaType { item_schema, .. }) => {
+                let item_type = SchemaType::from(item_schema);
+                let item_sig = item_type.type_signature_inner(true, defs, ref_stack, depth + 1)?;
+                if item_type.renders_union(defs)? {
+                    // handles case where the item is a union e.g. `(Foo | null)[]` vs the incorrect `Foo | null[]`
+                    format!("({item_sig})[]")
+                } else {
+                    format!("{item_sig}[]")
+                }
+            }
             SchemaType::Union(UnionSchemaType { union_schemas, .. }) => union_schemas
                 .iter()
                 .map(|s| SchemaType::from(s).type_signature_inner(true, defs, ref_stack, depth + 1))

--- a/crates/pctx_codegen/src/typegen/mod.rs
+++ b/crates/pctx_codegen/src/typegen/mod.rs
@@ -1,7 +1,5 @@
 mod schema_data;
 
-use std::collections::HashSet;
-
 use handlebars::Handlebars;
 use indexmap::IndexMap;
 use schemars::schema::{RootSchema, Schema};
@@ -79,19 +77,7 @@ fn normalize_root_schema(root_schema: RootSchema) -> CodegenResult<RootSchema> {
 }
 
 fn is_all_optional(schema: &Schema, defs: &SchemaDefinitions) -> CodegenResult<bool> {
-    // follow top schema until no longer ref
-    let mut schema_type = SchemaType::from(schema);
-    let mut visited = HashSet::new();
-    while let SchemaType::Reference(ref_st) = &schema_type {
-        let is_new = visited.insert(ref_st.ref_key.clone());
-        if is_new {
-            let followed = ref_st.follow(defs)?;
-            schema_type = SchemaType::from(followed);
-        } else {
-            // circular ref
-            break;
-        }
-    }
+    let schema_type = SchemaType::from(schema).deref(defs)?;
 
     // "all optional" means {} is a valid default
     // therefore all maps & objects with no required fields

--- a/crates/pctx_codegen/tests/fixtures/typegen/array.yml
+++ b/crates/pctx_codegen/tests/fixtures/typegen/array.yml
@@ -1,0 +1,200 @@
+# Various test cases for an array whose item signature is a union must be
+# parenthesised. Without it, `Foo | null[]` binds the `[]` to `null` rather than to
+# the union
+schema:
+  type: object
+  required:
+    - nullable_objects
+    - nullable_objects_one_of
+    - nullable_strings
+    - union_items
+    - enum_items
+    - nullable_refs
+    - nested_nullable
+    - map_of_nullable_arrays
+  properties:
+    nullable_objects:
+      description: 'the exact shape from #153 - `type: [object, "null"]` items'
+      type: array
+      items:
+        type: [object, "null"]
+        required:
+          - path
+        properties:
+          path:
+            type: string
+    nullable_objects_one_of:
+      description: the oneOf spelling of the same shape, which the issue notes is equally affected
+      type: array
+      items:
+        oneOf:
+          - type: object
+            required:
+              - path
+            properties:
+              path:
+                type: string
+          - type: "null"
+    nullable_strings:
+      description: nullable primitive items - `string | null[]` without parens
+      type: array
+      items:
+        type: [string, "null"]
+    union_items:
+      description: not null-specific - any union item signature needs grouping
+      type: array
+      items:
+        oneOf:
+          - type: string
+          - type: number
+    enum_items:
+      description: enum items render as `"a" | "b"`, so they need grouping too
+      type: array
+      items:
+        type: string
+        enum:
+          - alpha
+          - beta
+    nullable_refs:
+      description: a nullable $ref item, where the union is introduced after following the ref
+      type: array
+      items:
+        oneOf:
+          - $ref: "#/$defs/Document"
+          - type: "null"
+    nested_nullable:
+      description: array of arrays of nullable items - grouping has to survive nesting
+      type: array
+      items:
+        type: array
+        items:
+          type: [integer, "null"]
+    map_of_nullable_arrays:
+      description: the array sits behind a map value, so the fix must apply at any depth
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: [string, "null"]
+    optional_nullable_objects:
+      description: optional property whose items are nullable - `| undefined` must not be captured either
+      type: array
+      items:
+        type: [object, "null"]
+        required:
+          - path
+        properties:
+          path:
+            type: string
+  "$defs":
+    Document:
+      type: object
+      required:
+        - path
+      properties:
+        path:
+          type: string
+        size:
+          type: integer
+
+tests:
+  valid:
+    # The mixed arrays below are the load-bearing cases: under the `Foo | null[]`
+    # bug none of them type-check, because a mixed array is assignable to neither
+    # arm of the union.
+    - id: all-mixed
+      value:
+        nullable_objects: [{ path: a.txt }, null, { path: b.txt }]
+        nullable_objects_one_of: [null, { path: c.txt }]
+        nullable_strings: [one, null, two]
+        union_items: [text, 12, 3.4]
+        enum_items: [alpha, beta, alpha]
+        nullable_refs: [{ path: d.txt, size: 10 }, null]
+        nested_nullable: [[1, null], [null], [2, 3]]
+        map_of_nullable_arrays:
+          first: [a, null]
+          second: [null, b]
+        optional_nullable_objects: [{ path: e.txt }, null]
+    - id: optional-omitted
+      value:
+        nullable_objects: [{ path: a.txt }, null]
+        nullable_objects_one_of: [null]
+        nullable_strings: [null]
+        union_items: [1]
+        enum_items: [beta]
+        nullable_refs: [null]
+        nested_nullable: [[null]]
+        map_of_nullable_arrays: {}
+    - id: all-null-elements
+      value:
+        nullable_objects: [null, null]
+        nullable_objects_one_of: [null, null]
+        nullable_strings: [null, null]
+        union_items: []
+        enum_items: []
+        nullable_refs: [null, null]
+        nested_nullable: [[null, null]]
+        map_of_nullable_arrays:
+          only: [null]
+    - id: empty-arrays
+      value:
+        nullable_objects: []
+        nullable_objects_one_of: []
+        nullable_strings: []
+        union_items: []
+        enum_items: []
+        nullable_refs: []
+        nested_nullable: []
+        map_of_nullable_arrays: {}
+  invalid:
+    # These guard the other direction: parenthesising must not widen the element
+    # type into `any[]`, which would make the whole suite vacuous.
+    - id: wrong-element-type
+      value:
+        nullable_objects: [{ path: a.txt }, null]
+        nullable_objects_one_of: [null]
+        nullable_strings: [1, null]
+        union_items: [1]
+        enum_items: [alpha]
+        nullable_refs: [null]
+        nested_nullable: [[1]]
+        map_of_nullable_arrays: {}
+    - id: enum-value-not-in-enum
+      value:
+        nullable_objects: [null]
+        nullable_objects_one_of: [null]
+        nullable_strings: [null]
+        union_items: [1]
+        enum_items: [gamma]
+        nullable_refs: [null]
+        nested_nullable: [[1]]
+        map_of_nullable_arrays: {}
+    - id: null-array-itself
+      value:
+        nullable_objects: null
+        nullable_objects_one_of: [null]
+        nullable_strings: [null]
+        union_items: [1]
+        enum_items: [alpha]
+        nullable_refs: [null]
+        nested_nullable: [[1]]
+        map_of_nullable_arrays: {}
+    - id: not-nested-deep-enough
+      value:
+        nullable_objects: [null]
+        nullable_objects_one_of: [null]
+        nullable_strings: [null]
+        union_items: [1]
+        enum_items: [alpha]
+        nullable_refs: [null]
+        nested_nullable: [1, null]
+        map_of_nullable_arrays: {}
+    - id: required-missing
+      value:
+        nullable_objects_one_of: [null]
+        nullable_strings: [null]
+        union_items: [1]
+        enum_items: [alpha]
+        nullable_refs: [null]
+        nested_nullable: [[1]]
+        map_of_nullable_arrays: {}

--- a/crates/pctx_codegen/tests/snapshots/typegen__test_array.ts.snap
+++ b/crates/pctx_codegen/tests/snapshots/typegen__test_array.ts.snap
@@ -38,7 +38,9 @@ export type Array = {
   /**
    * optional property whose items are nullable - `| undefined` must not be captured either
    */
-  optional_nullable_objects?: (ArrayOptionalNullableObjects | null)[] | undefined;
+  optional_nullable_objects?:
+    | (ArrayOptionalNullableObjects | null)[]
+    | undefined;
 };
 
 export type ArrayNullableObjects = {

--- a/crates/pctx_codegen/tests/snapshots/typegen__test_array.ts.snap
+++ b/crates/pctx_codegen/tests/snapshots/typegen__test_array.ts.snap
@@ -1,0 +1,60 @@
+---
+source: crates/pctx_codegen/tests/typegen.rs
+expression: "&typegen_res.types"
+---
+export type Array = {
+  /**
+   * the exact shape from #153 - `type: [object, "null"]` items
+   */
+  nullable_objects: (ArrayNullableObjects | null)[];
+  /**
+   * the oneOf spelling of the same shape, which the issue notes is equally affected
+   */
+  nullable_objects_one_of: (ArrayNullableObjectsOneOfObj0 | null)[];
+  /**
+   * nullable primitive items - `string | null[]` without parens
+   */
+  nullable_strings: (string | null)[];
+  /**
+   * not null-specific - any union item signature needs grouping
+   */
+  union_items: (string | number)[];
+  /**
+   * enum items render as `"a" | "b"`, so they need grouping too
+   */
+  enum_items: ("alpha" | "beta")[];
+  /**
+   * a nullable $ref item, where the union is introduced after following the ref
+   */
+  nullable_refs: (ArrayDocument | null)[];
+  /**
+   * array of arrays of nullable items - grouping has to survive nesting
+   */
+  nested_nullable: (number | null)[][];
+  /**
+   * the array sits behind a map value, so the fix must apply at any depth
+   */
+  map_of_nullable_arrays: { [key: string]: (string | null)[] | undefined };
+  /**
+   * optional property whose items are nullable - `| undefined` must not be captured either
+   */
+  optional_nullable_objects?: (ArrayOptionalNullableObjects | null)[] | undefined;
+};
+
+export type ArrayNullableObjects = {
+  path: string;
+};
+
+export type ArrayNullableObjectsOneOfObj0 = {
+  path: string;
+};
+
+export type ArrayDocument = {
+  path: string;
+
+  size?: number | undefined;
+};
+
+export type ArrayOptionalNullableObjects = {
+  path: string;
+};

--- a/crates/pctx_codegen/tests/typegen.rs
+++ b/crates/pctx_codegen/tests/typegen.rs
@@ -98,3 +98,4 @@ typegen_test!(
     test_circular_references,
     include_str!("./fixtures/typegen/circular_references.yml")
 );
+typegen_test!(test_array, include_str!("./fixtures/typegen/array.yml"));


### PR DESCRIPTION
Fixes #153.

## Problem

An array whose items are a union rendered the item signature straight into `{}[]`, so `[]` bound to the last union arm instead of the whole union:

```ts
documents: ReadSourceDocumentsOutputDocuments | null[]   // an object, or an array of nulls
documents: (ReadSourceDocumentsOutputDocuments | null)[] // intended
```

Nothing could be done with the value — `.length`, `.map` and indexing all failed. Only visible at sandbox compile time; the schema itself validates fine.

## Fix

`schema_type.rs` — parenthesise the item signature when it renders a top-level union: the item is nullable (`apply_optional_modifiers` appends `| null`), an `Enum` with >1 option, or a `Union` with >1 schema.

## Why not the fix suggested in the ticket

The ticket suggests `if item_sig.contains(" | ")`. That string check double-wraps nested arrays, because the inner signature legitimately contains a `|`:

```ts
nested_nullable: ((number | null)[])[]   // contains(" | ")
nested_nullable: (number | null)[][]     // this PR
```

Both compile, but the redundant parens would spread to every array-of-array-of-union.

The check also runs after `deref`, because `type_signature_inner` inlines a reference's target rather than emitting its type name — so `items: { $ref: SomeUnion }` renders as `string | number` and needs the parens too. A bare variant check would see `Reference` and miss it. That ref-following loop already existed inlined in `is_all_optional`; it is now extracted as `SchemaType::deref` and shared.

## Tests

New `array.yml` typegen fixture covering nullable object items (the shape from the ticket), the `oneOf` spelling, nullable primitives, non-null unions, enums, nullable `$ref`s, nested arrays, arrays behind a map value, and an optional-and-nullable property. The harness type-checks the generated TS, so the mixed-element cases fail without the fix. Invalid cases guard the other direction — parenthesising must not widen elements to `any`.